### PR TITLE
Cluster model integrates with Variable in Storage

### DIFF
--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -3,26 +3,27 @@
 # User-configured attributes for cluster size & instance type
 class Cluster
   include ActiveModel::Model
+  include KeyPrefixable
+  extend KeyPrefixable
+
   attr_accessor :cloud_framework,
-    :instance_count, :instance_type, :instance_type_custom
+    :instance_count, :instance_type_custom
+  attr_writer :instance_type
 
   MIN_CLUSTER_SIZE = 3
   MAX_CLUSTER_SIZE = 250
 
   def initialize(*args)
     super
-    if @instance_type.blank? || @instance_type == 'CUSTOM'
-      @instance_type = @instance_type_custom
-    end
     @instance_count = @instance_count.to_i
   end
 
   def self.load
     new(
       cloud_framework:      KeyValue.get(:cloud_framework),
-      instance_count:       KeyValue.get(:instance_count),
-      instance_type:        KeyValue.get(:instance_type),
-      instance_type_custom: KeyValue.get(:instance_type_custom)
+      instance_count:       prefixed_get(:instance_count),
+      instance_type:        prefixed_get(:instance_type),
+      instance_type_custom: prefixed_get(:instance_type_custom)
     )
   end
 
@@ -31,6 +32,14 @@ class Cluster
       'instance_type',
       'instance_count'
     ]
+  end
+
+  def instance_type
+    if @instance_type.blank? || @instance_type == 'CUSTOM'
+      @instance_type_custom
+    else
+      @instance_type
+    end
   end
 
   def current_cluster_size
@@ -59,8 +68,9 @@ class Cluster
   end
 
   def save!
-    KeyValue.set(:instance_type, @instance_type)
-    KeyValue.set(:instance_count, @instance_count)
+    prefixed_set(:instance_type, @instance_type)
+    prefixed_set(:instance_type_custom, @instance_type)
+    prefixed_set(:instance_count, @instance_count)
   end
 
   def save

--- a/app/models/concerns/key_prefixable.rb
+++ b/app/models/concerns/key_prefixable.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# common module for shared key prefixing
+module KeyPrefixable
+  PREFIX = 'tfvars.'
+
+  def storage_key(key)
+    PREFIX + key.to_s
+  end
+
+  def prefixed_get(key, default=nil)
+    KeyValue.get(storage_key(key), default)
+  end
+
+  def prefixed_set(key, value)
+    KeyValue.set(storage_key(key), value)
+  end
+end

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -5,8 +5,7 @@
 # Non-string lists, non-string maps, and objects are not supported at this time.
 class Variable
   include ActiveModel::Model
-
-  KEY_PREFIX = 'tfvars.'
+  include KeyPrefixable
 
   def initialize(source_content)
     @plan = HCL::Checker.parse(source_content)['variable'] || {}
@@ -14,13 +13,9 @@ class Variable
       self.class.send(:attr_accessor, key)
       instance_variable_set(
         "@#{key}",
-        KeyValue.get(storage_key(key), default(key))
+        prefixed_get(key, default(key))
       )
     end
-  end
-
-  def storage_key(key)
-    KEY_PREFIX + key
   end
 
   def type(key)
@@ -83,7 +78,7 @@ class Variable
 
   def save!
     @plan.keys.each do |key|
-      KeyValue.set(storage_key(key), instance_variable_get("@#{key}"))
+      prefixed_set(key, instance_variable_get("@#{key}"))
     end
   end
 

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Cluster, type: :model do
 
   context 'when loading' do
     before do
-      KeyValue.set(:instance_type, custom_instance_type)
-      KeyValue.set(:instance_count, instance_count)
+      described_class.prefixed_set(:instance_type, custom_instance_type)
+      described_class.prefixed_set(:instance_count, instance_count)
     end
 
     it 'returns stored values' do
@@ -103,9 +103,10 @@ RSpec.describe Cluster, type: :model do
       )
     end
 
-    it 'stores instance type as :instance_type KeyValue' do
+    it 'stores instance type as prefixed :instance_type KeyValue' do
       expect(cluster.save).to be(true)
-      expect(KeyValue.get(:instance_type)).to eq(custom_instance_type)
+      expect(KeyValue.get(KeyPrefixable::PREFIX + 'instance_type'))
+        .to eq(custom_instance_type)
     end
 
     it 'describes the framework in string representation' do


### PR DESCRIPTION
The Cluster model now uses the same prefixed variables to store it's values as the Variable does; so instance_type and instance_count flow into the Variable attributes.