### PR TITLE
Flush logger

### DIFF
--- a/spec/controllers/plans_controller_spec.rb
+++ b/spec/controllers/plans_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PlansController, type: :controller do
 
     let(:ruby_terraform) { RubyTerraform }
 
-    let(:log_file) { File.open(expected_random_log_path, 'a') }
+    let(:log_file) { Logger::LogDevice.new(expected_random_log_path) }
 
     before do
       allow(controller).to receive(:terraform_plan)


### PR DESCRIPTION
With a normal approach of file + stdout,
it was necessary to add

  log_file.sync = true

for an implicit flushing, otherwise, there
were scenarios where not all the info was
written to log file.

This code fix that making use of LogDevice
where file sunchronisation is managed
automatically.