### PR TITLE
Update footer styling to EOS specifications

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -16,6 +16,16 @@
 }
 
 footer {
-  background-color: $eos-bc-blue-500;
-  color: $eos-bc-white;
+  margin-left: 250px;//250 sidebar width TODO - consider putting menu width into a shared variable
+  &.navbar {
+    padding-left: 25px;//the main content has a left-padding of 40, but container-fluid divs
+    // with the footer text, have a built-in pad of 15, so 40-15 = 25 to line up the footer with the content
+  }
+  span a, span a:hover {
+    color: $eos-bc-cerulean-900;
+  }
+}
+
+nav.active ~ footer {
+  margin-left: 50px; //250 sidebar width minus-200 for collapsed margin left
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,8 +16,8 @@
       %main.flex-shrink-0.container-fluid#content
         = bootstrap_flash
         = yield
-      %footer.navbar.navbar-expand-lg.fixed-bottom.navbar-dark
-        %div.container-fluid.d-flex.flex-row.justify-content-center
+      %footer.navbar.navbar-expand-lg.fixed-bottom
+        %div.container-fluid.d-flex.flex-row.justify-content-start
           %span.navbar-text.small
             = t('footer')
           %span.navbar-text.small

--- a/config/locales/custom-en.yml
+++ b/config/locales/custom-en.yml
@@ -14,4 +14,4 @@
 
 
     Hac arcu leo ac a vestibulum parturient suscipit parturient a suspendisse consectetur porta hac ullamcorper lacus turpis vestibulum scelerisque vel. Dictumst faucibus scelerisque et a scelerisque mattis vestibulum habitant id enim etiam venenatis mattis vitae luctus sodales potenti congue in scelerisque praesent class himenaeos consequat vivamus lorem dui. At consequat senectus ullamcorper scelerisque a id habitasse cum mi inceptos a condimentum sociis pretium rutrum fusce a imperdiet suspendisse nam id tellus. Consectetur volutpat at a sodales suspendisse tempus scelerisque a phasellus vulputate faucibus vestibulum sagittis a iaculis ipsum egestas convallis vitae libero scelerisque."
-    footer: "© 2019 SUSE, all rights reserved."
+    footer: "© 2019-2020 SUSE, all rights reserved."


### PR DESCRIPTION
Due to content length, footer remains in main content
area regardless of browser width. Footer aligns with
padding for main content area. Background, text color
and link colors updated to match eos specs.

eos footer spec: https://eosdesignsystem.herokuapp.com/layout/footer

![footer_menu_collapsed](https://user-images.githubusercontent.com/23247873/74064357-5acd6e00-49a7-11ea-88a6-49ffb3a7082c.png)
![footer_menu_expanded](https://user-images.githubusercontent.com/23247873/74064363-5d2fc800-49a7-11ea-86b6-0ca80db4753d.png)
