### PR TITLE
Restore background color to footer

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -17,6 +17,7 @@
 
 footer {
   margin-left: 250px;//250 sidebar width TODO - consider putting menu width into a shared variable
+  background-color: white;
   &.navbar {
     padding-left: 25px;//the main content has a left-padding of 40, but container-fluid divs
     // with the footer text, have a built-in pad of 15, so 40-15 = 25 to line up the footer with the content


### PR DESCRIPTION
![footer_solid_background](https://user-images.githubusercontent.com/23247873/74249490-1808e000-4c9e-11ea-922a-8ee97694835d.png)
The transparent background of the updated footer caused a "floating text" issue on pages that scroll (t wasnt noticeable on non-scrolling pages). This restores a solid background color to the footer, matching the color of the main content panel.