### PR TITLE
Terraform init failures, display error and route back to variables page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
   save: "Save"
   required: "Required"
   terraform_files: "terraform scripts and log"
+  terraform_init_error: "terraform failed to initialize"
   unauthorized: "Sorry, you can't do that, yet."
   password_show: "Show password"
   password_hide: "Hide password"


### PR DESCRIPTION
When terraform init fails, return to variables page and show error message at top of the page rather than displaying stack trace.

before:
![terra_init_error](https://user-images.githubusercontent.com/23247873/74547145-864cdd00-4f00-11ea-9f1e-31a9700f4eb6.png)

after:
![terra_init_error_fixed](https://user-images.githubusercontent.com/23247873/74547149-8816a080-4f00-11ea-8340-769db04ead4e.png)
