### PR TITLE
Update 'password' rendering in variables page

### DIFF
--- a/app/views/variables/_password.html.haml
+++ b/app/views/variables/_password.html.haml
@@ -1,0 +1,5 @@
+%div.form-group{ class: key }
+  %label{ for: "variables[#{key}]" }= key.titleize
+  %input.form-control{ type: 'password', name: "variables[#{key}]", value: value }
+  - if defined?(description)
+    %small.form-text.text-muted= description

--- a/app/views/variables/show.html.haml
+++ b/app/views/variables/show.html.haml
@@ -4,7 +4,10 @@
     %div.card-body.variables
       - @variables.attributes.each do |key, value|
         - next if @excluded.include?(key)
-        = render(@variables.type(key), key: key, value: value, description: @variables.description(key))
+        - if @variables.description(key) && @variables.description(key).include?(t('password_key')) && @variables.type(key).include?('string')
+          = render('password', key: key, value: value, description: @variables.description(key))
+        - else
+          = render(@variables.type(key), key: key, value: value, description: @variables.description(key))
   %p.clearfix
   %div.float-right.btn-group.steps-container
     = link_to cluster_path, class: "btn btn-secondary", title: t('tooltips.prior_step'), data: { toggle: 'tooltip' } do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,10 @@ en:
   hello: "Hello world"
   save: "Save"
   terraform_files: "terraform scripts and log"
+  
+  #password key is used to check whether a form field should be of type
+  # "password" rather than "text"
+  password_key: "password"
 
   sidebar:
     welcome: "Welcome"


### PR DESCRIPTION
Variables with 'password; in the description are rendered as
password type rather than text. The text checked for this is
localized to support description localization without losing
the password check functionality