### PR TITLE
Only allow one session at a time

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   before_action :authorize
 
   def authorize
+    active_session = helpers.active_session?
+    @active_session_ip = KeyValue.get(:active_session_ip) unless active_session
     return if helpers.can(request.path)
 
     flash[:error] = t(:unauthorized)

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -12,4 +12,10 @@ class WelcomeController < ApplicationController
     Rails.configuration.x.advanced_mode = false
     redirect_to cluster_path
   end
+
+  def reset_session
+    helpers.set_session!
+    flash[:alert] = t(:session_reset)
+    redirect_to welcome_path
+  end
 end

--- a/app/views/layouts/_locked_session.html.haml
+++ b/app/views/layouts/_locked_session.html.haml
@@ -1,0 +1,20 @@
+%div.modal#locked-session{ data: { backdrop: 'static' } }
+  %div.modal-dialog
+    %div.modal-content
+      %div.modal-header
+        %h3.modal-title= t('non_active_session')
+      %div.modal-body
+        = markdown(t('content.explain_duplicate_session'))
+        = markdown(t('content.label_active_session_ip', ip: ip_address))
+
+      %div.modal-footer
+        = link_to reset_session_path, method: :put, class: 'btn btn-danger' do
+          %i.eos-icons.md-18 delete_forever
+          = t('action.reset_session')
+
+= content_for :page_javascript do
+  :javascript
+    $(function(){
+      $('#locked-session').modal('show');
+    });
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,5 +26,7 @@
             released under the&nbsp;
             %a{ href: Rails.configuration.x.source_link + 'blob/master/LICENSE' , target: '_blank', rel: 'noopener noreferrer' }> GPLv3 license
             \.
+    - if @active_session_ip
+      = render 'layouts/locked_session', ip_address: @active_session_ip
     = javascript_include_tag 'application'
     = yield :page_javascript

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,8 @@ en:
   required: "Required"
   terraform_files: "terraform scripts and log"
   unauthorized: "Sorry, you can't do that, yet."
+  non_active_session: "Duplicate session!"
+  session_reset: "The active session has been reset."
   password_show: "Show password"
   password_hide: "Hide password"
   autoscroll: "Autoscroll"
@@ -42,9 +44,12 @@ en:
   #password key is used to check whether a form field should be of type
   # "password" rather than "text"
   password_key: "password"
+
   plan: "Plan"
   apply: "Apply"
   running: "Running..."
+  action:
+    reset_session: "Reset session"
 
   sidebar:
     welcome: "Welcome"
@@ -82,3 +87,11 @@ en:
     wrapup_info: |
       Your application has been deployed, here's how to use it.
       [Download](/download) your results and follow the instructions below.
+
+  content:
+    explain_duplicate_session: |
+      Someone is already logged into this application, but this application is only intended for one user at a time.
+
+      Please switch back to the active session if possible. If not, you may reset the active session.
+    label_active_session_ip: |
+      Active session IP address: `%{ip}`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   # switch paths
   get '/welcome/simple', to: 'welcome#simple', as: 'simple'
   get '/welcome/advanced', to: 'welcome#advanced', as: 'advanced'
+  put '/welcome/reset-session', to: 'welcome#reset_session', as: 'reset_session'
 
   # Cluster size
   resource :cluster, only: [:show, :update]


### PR DESCRIPTION
Store the current session ID, pop a modal if another session accesses, but allow the user to unlock the session.

This is a start on https://github.com/SUSE-Enceladus/blue-horizon/issues/84 but I still need to implement some locking around plan & deploy.