### PR TITLE
Create multi select variables layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ _blue-horizon_ is pointless, without a set of terraform scripts to work from, an
 
 **NOTE:** _The content of those files will be stored in the database, and may be edited by the application user. When terraform runs, it will run on exported content from the database, so it may not be identical to what was initially provided in `vendor/sources`._
 
-Variables **must** be defined in terraform JSON format, and named `variable*.tf.json`. Variables will be _required_ unless the description includes the word "optional".
+Variables **must** be defined in terraform JSON format, and named `variable*.tf.json`. Here some additional tips to customize your variables options:
+- Variables will be _required_ unless the description includes the word "optional".
+- Variables with "password" word in the description will be configured as password inputs hiding the content. This keyword value can be changed in the `en.yml` configuration file changing `password_key` entry.
+- Variables with "options=["option1", "option2"]" content in the description will create a multi option input. This keyword value can be changed in the `en.yml` configuration file changing `options_key` entry.
 
 To use a different path, set the environment variable `TERRAFORM_SOURCES_PATH` before seeding the database.
 

--- a/app/helpers/variables_helper.rb
+++ b/app/helpers/variables_helper.rb
@@ -12,10 +12,25 @@ module VariablesHelper
   end
 
   def string_input_type(description)
-    if description.to_s.downcase.include?(t('password_key'))
+    if description.to_s.downcase.match?('.*' + t('options_key') + '=\[(.*)\].*')
+      'select'
+    elsif description.to_s.downcase.include?(t('password_key'))
       'password'
     else
       'text'
     end
+  end
+
+  def get_select_options(description)
+    # We cannot downcase the string as this would change the options string
+    # The next operation converts the options_key in a lower/upper case regex
+    key_regular_expression = t('options_key').split('').map do |char|
+      format('[%<up>s|%<down>s]', up: char.upcase, down: char.downcase)
+    end
+    key_regular_expression = key_regular_expression.join('')
+    options = description.to_s.match(
+      '.*' + key_regular_expression + '=\[(.*)\].*'
+    ).captures
+    options[0].split(',').map { |option| option.tr('\'\"', '').strip }
   end
 end

--- a/app/views/variables/_string.html.haml
+++ b/app/views/variables/_string.html.haml
@@ -4,7 +4,13 @@
     = key.titleize
     = required if @variables.required?(key)
   %div.input-group
-    %input.form-control{ type: fieldtype, name: "variables[#{key}]", value: value, required: @variables.required?(key) }
+    - if fieldtype == 'select'
+      - @options = get_select_options(description)
+      %select.form-control{ name: "variables[#{key}]" }
+        - @options.each do |option|
+          %option{value: option, selected: value == option}= option
+    - else
+      %input.form-control{ type: fieldtype, name: "variables[#{key}]", value: value, required: @variables.required?(key) }
     - if fieldtype == 'password'
       %div.input-group-append
         %button.btn.btn-outline-warning.peek{ id: "peek_#{key}", type: 'button', data: { toggle: 'tooltip' }, title: t(:password_show) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,8 @@ en:
   #password key is used to check whether a form field should be of type
   # "password" rather than "text"
   password_key: "password"
+  #options key is used to create a multi select input rather than normal "text"
+  options_key: "options"
 
   plan: "Plan"
   apply: "Apply"

--- a/spec/features/variable_editing_spec.rb
+++ b/spec/features/variable_editing_spec.rb
@@ -30,7 +30,9 @@ describe 'variable editing', type: :feature do
     it 'stores form data for variables' do
       random_variable_key = nil
       until random_variable_key &&
-            variables.type(random_variable_key) == 'string'
+            variables.type(random_variable_key) == 'string' &&
+            (variables.description(random_variable_key).nil? ||
+            !variables.description(random_variable_key).include?('options'))
         random_variable_key = (variable_names - exclusions).sample
       end
       fill_in("variables[#{random_variable_key}]", with: fake_data)
@@ -41,10 +43,25 @@ describe 'variable editing', type: :feature do
       expect(page).to have_content('Variables were successfully updated.')
     end
 
+    it 'stores form data for variables in multi options input' do
+      expect(page).to have_select 'variables[test_options]',
+        with_options: ['option1', 'option2']
+      ['option1', 'option2'].each do |option_value|
+        select(option_value, from: 'variables[test_options]')
+        click_on('Save')
+
+        expect(KeyValue.get(variables.storage_key('test_options')))
+          .to eq(option_value)
+        expect(page).to have_content('Variables were successfully updated.')
+      end
+    end
+
     it 'fails to update and shows error' do
       random_variable_key = nil
       until random_variable_key &&
-            variables.type(random_variable_key) == 'string'
+            variables.type(random_variable_key) == 'string' &&
+            (variables.description(random_variable_key).nil? ||
+            !variables.description(random_variable_key).include?('options'))
         random_variable_key = (variable_names - exclusions).sample
       end
       fill_in("variables[#{random_variable_key}]", with: fake_data)

--- a/spec/fixtures/sources/variable-mocks.tf.json
+++ b/spec/fixtures/sources/variable-mocks.tf.json
@@ -22,6 +22,9 @@
         },
         "test_password": {
             "description": "Password is optional"
+        },
+        "test_options": {
+            "description": "Multi Options=[\"option1\", \"option2\"]"
         }
     }
 }

--- a/spec/helpers/authorization_helper_spec.rb
+++ b/spec/helpers/authorization_helper_spec.rb
@@ -15,7 +15,8 @@ describe AuthorizationHelper do
       'are_you_sure'     => 'true',
       'test_list'        => ['one', 'two', 'three'],
       'test_map'         => { foo: 'bar' },
-      'test_string'      => random_string
+      'test_string'      => random_string,
+      'test_options'     => 'option2'
     }
   end
   let(:terra) { Terraform }

--- a/spec/models/variable_spec.rb
+++ b/spec/models/variable_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Variable, type: :model do
       'test_list'        => ['one', 'two', 'three'],
       'test_map'         => { foo: 'bar' },
       'test_password'    => 'Superman123!',
+      'test_options'     => 'option1',
       'fake_key'         => 'fake_value'
     }
   end
@@ -89,6 +90,7 @@ RSpec.describe Variable, type: :model do
         'empty_number',
         'test_description',
         'test_password',
+        'test_options',
         'name'
       ]
     end


### PR DESCRIPTION
Hi all,

This PR adds the option to create multi select kind of variables. This is really helpful when the terraform scripts has defined set of options for some variables, and we want to make sure that the user will use only the allowed one.

My doubt is if the `get_select_options` method should go in the variables model. Maybe it's better (as `select_type?`)

Here a image with the feature (sorry for the quality, I was not able to make a screenshot as the tab was being hidden all the time...)
![image](https://user-images.githubusercontent.com/36370954/85141325-83f7e800-b23e-11ea-9c9a-36abefd502b7.png)


@bear454 @jesusbv Could you have a look? If you like the implementation I will add the required UT for the new methods and changes