### PR TITLE
Better descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Variables **must** be defined in terraform JSON format, and named `variable*.tf.
 - Variables will be _required_ unless the description includes the word "optional".
 - Variables with "password" word in the description will be configured as password inputs hiding the content. This keyword value can be changed in the `en.yml` configuration file changing `password_key` entry.
 - Variables with "options=["option1", "option2"]" content in the description will create a multi option input. This keyword value can be changed in the `en.yml` configuration file changing `options_key` entry.
-- Variable descriptions may include a comment that is not displayed. Any content following `//` will not be included in the UI, but _will_ be parsed for other customization flags.
+- Variable descriptions may include a comment that is not displayed. Any content contained in an HTML comment block `<!-- like this -->` will not be included in the UI, but _will_ be parsed for other customization flags.
+- Variable descriptions will be rendered as inline _markdown_ in the UI. 
 
 To use a different path, set the environment variable `TERRAFORM_SOURCES_PATH` before seeding the database.
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,10 +69,14 @@ module ApplicationHelper
       space_after_headers: true,
       no_intra_emphasis:   true
     }
+    # Redcarpet doesn't remove HTML comments even with `filter_html: true`
+    # https://github.com/vmg/redcarpet/issues/692
+    uncommented_text = text.gsub(/<!--(.*?)-->/,'')
+
     markdown = Redcarpet::Markdown.new(
       Redcarpet::Render::HTML.new(escape_html: escape_html),
       options
     )
-    markdown.render(text).html_safe
+    markdown.render(uncommented_text).html_safe
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,18 +64,31 @@ module ApplicationHelper
   def markdown(text, escape_html=true)
     return '' if text.blank?
 
-    options = {
+    markdown_options = {
       autolink:            true,
       space_after_headers: true,
-      no_intra_emphasis:   true
+      no_intra_emphasis:   true,
+      fenced_code_blocks:  true,
+      strikethrough:       true,
+      superscript:         true,
+      underline:           true,
+      highlight:           true,
+      quote:               true
     }
+    render_options = {
+      filter_html: true,
+      no_images: true,
+      no_styles: true
+    }
+    render_options[:escape_html] = true if escape_html
+
     # Redcarpet doesn't remove HTML comments even with `filter_html: true`
     # https://github.com/vmg/redcarpet/issues/692
     uncommented_text = text.gsub(/<!--(.*?)-->/,'')
 
     markdown = Redcarpet::Markdown.new(
-      Redcarpet::Render::HTML.new(escape_html: escape_html),
-      options
+      Redcarpet::Render::HTML.new(render_options),
+      markdown_options
     )
     markdown.render(uncommented_text).html_safe
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -77,14 +77,14 @@ module ApplicationHelper
     }
     render_options = {
       filter_html: true,
-      no_images: true,
-      no_styles: true
+      no_images:   true,
+      no_styles:   true
     }
     render_options[:escape_html] = true if escape_html
 
     # Redcarpet doesn't remove HTML comments even with `filter_html: true`
     # https://github.com/vmg/redcarpet/issues/692
-    uncommented_text = text.gsub(/<!--(.*?)-->/,'')
+    uncommented_text = text.gsub(/<!--(.*?)-->/, '')
 
     markdown = Redcarpet::Markdown.new(
       Redcarpet::Render::HTML.new(render_options),

--- a/app/helpers/variables_helper.rb
+++ b/app/helpers/variables_helper.rb
@@ -16,7 +16,7 @@ module VariablesHelper
 
     content_tag(
       :small,
-      description.split('//').first,
+      markdown(description, escape_html=false),
       class: ['form-text', 'text-muted']
     )
   end

--- a/app/helpers/variables_helper.rb
+++ b/app/helpers/variables_helper.rb
@@ -16,7 +16,7 @@ module VariablesHelper
 
     content_tag(
       :small,
-      markdown(description, escape_html=false),
+      markdown(description, false),
       class: ['form-text', 'text-muted']
     )
   end

--- a/spec/features/variable_editing_spec.rb
+++ b/spec/features/variable_editing_spec.rb
@@ -58,7 +58,7 @@ describe 'variable editing', type: :feature do
 
     it 'does not display description comments' do
       expect(page).to have_content 'Some things'
-      expect(page).not_to have_content '// are best left unsaid'
+      expect(page).not_to have_content 'are best left unsaid'
     end
 
     it 'fails to update and shows error' do

--- a/spec/fixtures/sources/variable-mocks.tf.json
+++ b/spec/fixtures/sources/variable-mocks.tf.json
@@ -27,7 +27,7 @@
             "description": "Multi Options=[\"option1\", \"option2\"]"
         },
         "test_description_comment": {
-            "description": "Some things // are best left unsaid",
+            "description": "Some things <!-- are best left unsaid -->",
             "default": "be quiet"
         }
     }


### PR DESCRIPTION
#126 inadvertently broke HTML hyperlinks in description comments, by treating the "//" in "http://..." as a comment marker.

Going back and rethinking, it made more sense to enhance the descriptions by making the hyperlinks active, and alllowing some small markup as well... so I enabled _markdown_ rendering of the descriptions instead, and used HTML comments for unrendered content.

Unfortunately, Redcarpet doesn't handle HTML comments nicely in v3.5.0 ( https://github.com/vmg/redcarpet/issues/692 ), so I had to strip them out before rendering as _markdown_.