### PR TITLE
Simplify options handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ _blue-horizon_ is pointless, without a set of terraform scripts to work from, an
 Variables **must** be defined in terraform JSON format, and named `variable*.tf.json`. Here some additional tips to customize your variables options:
 - Variables will be _required_ unless the description includes the word "optional".
 - Variables with "password" word in the description will be configured as password inputs hiding the content. This keyword value can be changed in the `en.yml` configuration file changing `password_key` entry.
-- Variables with `options=["option1", "option2"]` content in the description will create a multi option input. This keyword value can be changed in the `en.yml` configuration file changing `options_key` entry.
+- Variables with `options=[option1,option2]` content in the description will create a multi option input. Options are comma-separated, but may include any other punctuation, or spaces. The keyword value can be changed in the `en.yml` configuration file changing `options_key` entry.
 - Variables with `[group:some_group_name]` will be grouped together (but still listed as ordered in the variables file). The group name will be pulled form I18N configuration, or otherwise titleized. (e.g. `[group:important_things] will render as 'Important Things')
 - Variable descriptions may include a comment that is not displayed. Any content contained in an HTML comment block `<!-- like this -->` will not be included in the UI, but _will_ be parsed for other customization flags.
 - Variable descriptions will be rendered as inline _markdown_ in the UI.

--- a/app/helpers/variables_helper.rb
+++ b/app/helpers/variables_helper.rb
@@ -17,10 +17,16 @@ module VariablesHelper
     )
   end
 
+  def options_regex
+    /#{t('options_key')}=\[(?<options>.*?)\]/i
+  end
+
   def string_input_type(description)
-    if description.to_s.downcase.match?(".*#{t('options_key')}=\\[(.*)\\].*")
+    return 'text' unless description
+
+    if description.match?(options_regex)
       'select'
-    elsif description.to_s.downcase.include?(t('password_key'))
+    elsif description.match?(/#{t('password_key')}/i)
       'password'
     else
       'text'
@@ -28,15 +34,8 @@ module VariablesHelper
   end
 
   def get_select_options(description)
-    # We cannot downcase the string as this would change the options string
-    # The next operation converts the options_key in a lower/upper case regex
-    key_regular_expression = t('options_key').split('').map do |char|
-      format('[%<up>s|%<down>s]', up: char.upcase, down: char.downcase)
-    end
-    key_regular_expression = key_regular_expression.join('')
-    options = description.to_s.match(
-      ".*#{key_regular_expression}=\\[(.*)\\].*"
-    ).captures
-    options[0].split(',').map { |option| option.tr('\'\"', '').strip }
+    description.match(options_regex)[:options].split(',')
+  rescue StandardError
+    []
   end
 end

--- a/spec/fixtures/sources/variable-mocks.tf.json
+++ b/spec/fixtures/sources/variable-mocks.tf.json
@@ -24,7 +24,7 @@
             "description": "Password is optional"
         },
         "test_options": {
-            "description": "Multi Options=[\"option1\", \"option2\"]"
+            "description": "Multi Options=[option1,option2]"
         },
         "test_description_comment": {
             "description": "Some things <!-- are best left unsaid -->",

--- a/spec/helpers/variables_helper_spec.rb
+++ b/spec/helpers/variables_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VariablesHelper do
+  context 'when selecting options from a description' do
+    context 'when something goes sideways' do
+      it 'returns an empty list' do
+        expect(helper.get_select_options(nil)).to eq([])
+      end
+    end
+  end
+end

--- a/spec/helpers/variables_helper_spec.rb
+++ b/spec/helpers/variables_helper_spec.rb
@@ -3,7 +3,20 @@
 require 'rails_helper'
 
 describe VariablesHelper do
+  let(:mock_description) do
+    'This description has options and groups in a comment'\
+    '<!-- options=[foo,bar] [group:baz] -->'
+  end
+  let(:expected_options) do
+    ['foo', 'bar']
+  end
+
   context 'when selecting options from a description' do
+    it 'only parses the options set' do
+      expect(helper.get_select_options(mock_description))
+        .to eq(expected_options)
+    end
+
     context 'when something goes sideways' do
       it 'returns an empty list' do
         expect(helper.get_select_options(nil)).to eq([])


### PR DESCRIPTION
* use case-insensitive non-greedy regex
* remove requirements/handler for quotes around options
* add an error handler

Resolves https://github.com/SUSE-Enceladus/blue-horizon/issues/155