### PR TITLE
Simplify navigation on variables page

### DIFF
--- a/app/controllers/variables_controller.rb
+++ b/app/controllers/variables_controller.rb
@@ -12,23 +12,12 @@ class VariablesController < ApplicationController
   end
 
   def update
-    params[:variables][:cluster_labels] ||= {}
-
     @variables.attributes = variables_params
-    if @variables.save
-      flash_message = {}
-      if params[:button]
-        target_path = plan_path
-      else
-        flash_message = { notice: 'Variables were successfully updated.' }
-        target_path = variables_path
-      end
-      redirect_to target_path, flash: flash_message
-    else
-      redirect_to variables_path, flash: {
-        error: @variables.errors.full_messages
-      }
-    end
+    redirect_to plan_path and return if @variables.save
+
+    redirect_to variables_path, flash: {
+      error: @variables.errors.full_messages
+    }
   end
 
   private
@@ -54,6 +43,7 @@ class VariablesController < ApplicationController
   end
 
   def variables_params
+    params[:variables][:cluster_labels] ||= {}
     params.require(:variables).permit(@variables.strong_params)
   end
 end

--- a/app/views/variables/show.html.haml
+++ b/app/views/variables/show.html.haml
@@ -11,10 +11,7 @@
     = link_to cluster_path, class: "btn btn-secondary", title: t('tooltips.prior_step'), data: { toggle: 'tooltip' } do
       %i.eos-icons fast_rewind
       = t('sidebar.cluster')
-    %button.btn.btn-outline-primary#submit-cluster{ type: 'submit', title: t('tooltips.save'), data: { toggle: 'tooltip' } }
-      %i.eos-icons save
-      = t('save')
-    = button_tag variables_path, method: :put, class: "btn btn-primary", title: t('tooltips.start_action'), data: { toggle: 'tooltip' }, id: 'next' do
+    %button.btn.btn-primary#next{ type: 'submit', title: t('tooltips.start_action'), data: { toggle: 'tooltip' } }
       %i.eos-icons fast_forward
       = t('sidebar.plan')
 %p.clearfix

--- a/spec/features/variable_editing_spec.rb
+++ b/spec/features/variable_editing_spec.rb
@@ -45,23 +45,24 @@ describe 'variable editing', type: :feature do
         random_variable_key = (variable_names - exclusions).sample
       end
       fill_in("variables[#{random_variable_key}]", with: fake_data)
-      click_on('Save')
+      find('#next').click
 
       expect(KeyValue.get(variables.storage_key(random_variable_key)))
         .to eq(fake_data)
-      expect(page).to have_content('Variables were successfully updated.')
     end
 
     it 'stores form data for variables in multi options input' do
-      expect(page).to have_select 'variables[test_options]',
-        with_options: ['option1', 'option2']
       ['option1', 'option2'].each do |option_value|
+        visit('/variables')
+        expect(page).to have_select(
+          'variables[test_options]',
+          with_options: ['option1', 'option2']
+        )
         select(option_value, from: 'variables[test_options]')
-        click_on('Save')
+        find('#next').click
 
         expect(KeyValue.get(variables.storage_key('test_options')))
           .to eq(option_value)
-        expect(page).to have_content('Variables were successfully updated.')
       end
     end
 
@@ -85,7 +86,7 @@ describe 'variable editing', type: :feature do
         e.add(:variable, 'is wrong')
       end
       allow(variables).to receive(:errors).and_return(active_model_errors)
-      click_on('Save')
+      find('#next').click
 
       expect(page).not_to have_content('Variables were successfully updated.')
       expect(page).to have_content('Variable is wrong')


### PR DESCRIPTION
Save data and move on to plan by default. If there is a problem, fall back to variables form.

This was the behavior of the 'plan' button anyway; just dropping the redundant 'save' button.