### PR TITLE
Add client side variables validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Variables **must** be defined in terraform JSON format, and named `variable*.tf.
 - Variables with "password" word in the description will be configured as password inputs hiding the content. This keyword value can be changed in the `en.yml` configuration file changing `password_key` entry.
 - Variables with `options=[option1,option2]` content in the description will create a multi option input. Options are comma-separated, but may include any other punctuation, or spaces. The keyword value can be changed in the `en.yml` configuration file changing `options_key` entry.
 - Variables with `[group:some_group_name]` will be grouped together (but still listed as ordered in the variables file). The group name will be pulled form I18N configuration, or otherwise titleized. (e.g. `[group:important_things]` will render as 'Important Things')
-- Variables with `[pattern:[a-zA-Z]{3}:endpattern]` will have a client side validation to check if the input string is valid.
+- Variables with `[pattern:/my expression/]` will have a client side validation to check if the input string is valid.
 - Variables with `[title:my variable title]` will have the provided content as input title. This option combines together with the pattern option to display the error message if the pattern validation fails.
 - Variable descriptions may include a comment that is not displayed. Any content contained in an HTML comment block `<!-- like this -->` will not be included in the UI, but _will_ be parsed for other customization flags.
 - Variable descriptions will be rendered as inline _markdown_ in the UI.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The Ruby project uses [rvm](http://rvm.io/rvm/basics) to manage a virtual enviro
     ```
     sudo zypper in libxml2-devel libxslt-devel sqlite3-devel
     ```
-    
+
 
 4.  If you need to use a path _other than_ `./vendor/` for customization, create a dotenv file (e.g. `.env.development`) that defines:
     *   The path to the customization JSON:
@@ -84,7 +84,9 @@ Variables **must** be defined in terraform JSON format, and named `variable*.tf.
 - Variables will be _required_ unless the description includes the word "optional".
 - Variables with "password" word in the description will be configured as password inputs hiding the content. This keyword value can be changed in the `en.yml` configuration file changing `password_key` entry.
 - Variables with `options=[option1,option2]` content in the description will create a multi option input. Options are comma-separated, but may include any other punctuation, or spaces. The keyword value can be changed in the `en.yml` configuration file changing `options_key` entry.
-- Variables with `[group:some_group_name]` will be grouped together (but still listed as ordered in the variables file). The group name will be pulled form I18N configuration, or otherwise titleized. (e.g. `[group:important_things] will render as 'Important Things')
+- Variables with `[group:some_group_name]` will be grouped together (but still listed as ordered in the variables file). The group name will be pulled form I18N configuration, or otherwise titleized. (e.g. `[group:important_things]` will render as 'Important Things')
+- Variables with `[pattern:[a-zA-Z]{3}:endpattern]` will have a client side validation to check if the input string is valid.
+- Variables with `[title:my variable title]` will have the provided content as input title. This option combines together with the pattern option to display the error message if the pattern validation fails.
 - Variable descriptions may include a comment that is not displayed. Any content contained in an HTML comment block `<!-- like this -->` will not be included in the UI, but _will_ be parsed for other customization flags.
 - Variable descriptions will be rendered as inline _markdown_ in the UI.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Variables **must** be defined in terraform JSON format, and named `variable*.tf.
 - Variables with `options=[option1,option2]` content in the description will create a multi option input. Options are comma-separated, but may include any other punctuation, or spaces. The keyword value can be changed in the `en.yml` configuration file changing `options_key` entry.
 - Variables with `[group:some_group_name]` will be grouped together (but still listed as ordered in the variables file). The group name will be pulled form I18N configuration, or otherwise titleized. (e.g. `[group:important_things]` will render as 'Important Things')
 - Variables with `[pattern:/my expression/]` will have a client side validation to check if the input string is valid.
-- Variables with `[title:my variable title]` will have the provided content as input title. This option combines together with the pattern option to display the error message if the pattern validation fails.
+- Variables with `[extra_information:my variable information]` will have the provided content in the input title attribute, which creates a tooltip text when the mouse moves over the element. This option combines together with the pattern option to display the error message if the pattern validation fails.
 - Variable descriptions may include a comment that is not displayed. Any content contained in an HTML comment block `<!-- like this -->` will not be included in the UI, but _will_ be parsed for other customization flags.
 - Variable descriptions will be rendered as inline _markdown_ in the UI.
 

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -69,7 +69,7 @@ class Variable
   end
 
   def pattern(key)
-    /\[pattern:(?<pattern>.+):endpattern?\]/.match(
+    %r{\[pattern:/(?<pattern>.+):?/\]}.match(
       @plan[key]['description']
     )[:pattern]
   rescue StandardError

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -77,7 +77,9 @@ class Variable
   end
 
   def title(key)
-    /\[title:(?<title>.+?)\]/.match(@plan[key]['description'])[:title]
+    /\[extra_information:(?<title>.+?)\]/.match(
+      @plan[key]['description']
+    )[:title]
   rescue StandardError
     ''
   end

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -68,8 +68,22 @@ class Variable
     !(/optional/i =~ @plan[key]['description'])
   end
 
+  def pattern(key)
+    /\[pattern:(?<pattern>.+):endpattern?\]/.match(
+      @plan[key]['description']
+    )[:pattern]
+  rescue StandardError
+    '.*'
+  end
+
+  def title(key)
+    /\[title:(?<title>.+?)\]/.match(@plan[key]['description'])[:title]
+  rescue StandardError
+    ''
+  end
+
   def group(key)
-    /\[group:(?<group>.+)?\]/.match(@plan[key]['description'])[:group]
+    /\[group:(?<group>.+?)\]/.match(@plan[key]['description'])[:group]
   rescue StandardError
     UNGROUPED
   end

--- a/app/views/variables/_string.html.haml
+++ b/app/views/variables/_string.html.haml
@@ -10,7 +10,7 @@
         - @options.each do |option|
           %option{value: option, selected: value == option}= option
     - else
-      %input.form-control{ type: fieldtype, name: "variables[#{key}]", value: value, required: @variables.required?(key) }
+      %input.form-control{ type: fieldtype, name: "variables[#{key}]", value: value, required: @variables.required?(key), pattern: @variables.pattern(key), title: @variables.title(key) }
     - if fieldtype == 'password'
       %button.btn.btn-sm.btn-secondary.peek{ id: "peek_#{key}", type: 'button', data: { toggle: 'tooltip' }, title: t(:password_show) }
         &nbsp;

--- a/spec/features/variable_editing_spec.rb
+++ b/spec/features/variable_editing_spec.rb
@@ -70,6 +70,12 @@ describe 'variable editing', type: :feature do
       expect(page).not_to have_content 'are best left unsaid'
     end
 
+    it 'stores from data for variables validating the pattern' do
+      pattern_input = page.find("[name|='variables[test_pattern]']")
+      expect(pattern_input[:title]).to eq('2 digits string')
+      expect(pattern_input[:pattern]).to eq('[0-9]{2}')
+    end
+
     it 'fails to update and shows error' do
       random_variable_key = nil
       until random_variable_key &&

--- a/spec/fixtures/sources/variable-mocks.tf.json
+++ b/spec/fixtures/sources/variable-mocks.tf.json
@@ -30,6 +30,9 @@
             "description": "Some things <!-- are best left unsaid -->",
             "default": "be quiet"
         },
+        "test_pattern": {
+            "description": "Variable with pattern [pattern:[0-9]{2}:endpattern] [title:2 digits string]"
+        },
         "region": {
             "type": "string",
             "description": "Cloud region where this is running. (Optional)"

--- a/spec/fixtures/sources/variable-mocks.tf.json
+++ b/spec/fixtures/sources/variable-mocks.tf.json
@@ -31,7 +31,7 @@
             "default": "be quiet"
         },
         "test_pattern": {
-            "description": "Variable with pattern [pattern:[0-9]{2}:endpattern] [title:2 digits string]"
+            "description": "Variable with pattern [pattern:/[0-9]{2}/] [title:2 digits string]"
         },
         "region": {
             "type": "string",

--- a/spec/fixtures/sources/variable-mocks.tf.json
+++ b/spec/fixtures/sources/variable-mocks.tf.json
@@ -31,7 +31,7 @@
             "default": "be quiet"
         },
         "test_pattern": {
-            "description": "Variable with pattern [pattern:/[0-9]{2}/] [title:2 digits string]"
+            "description": "Variable with pattern [pattern:/[0-9]{2}/] [extra_information:2 digits string]"
         },
         "region": {
             "type": "string",

--- a/spec/helpers/authorization_helper_spec.rb
+++ b/spec/helpers/authorization_helper_spec.rb
@@ -16,7 +16,8 @@ describe AuthorizationHelper do
       'test_list'        => ['one', 'two', 'three'],
       'test_map'         => { foo: 'bar' },
       'test_string'      => random_string,
-      'test_options'     => 'option2'
+      'test_options'     => 'option2',
+      'test_pattern'     => '00'
     }
   end
   let(:terra) { Terraform }

--- a/spec/models/variable_spec.rb
+++ b/spec/models/variable_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Variable, type: :model do
       'test_map'         => { foo: 'bar' },
       'test_password'    => 'Superman123!',
       'test_options'     => 'option1',
+      'test_pattern'     => '00',
       'fake_key'         => 'fake_value',
       'region'           => random_string
     }
@@ -34,6 +35,7 @@ RSpec.describe Variable, type: :model do
       'test_description',
       'test_password',
       'test_options',
+      'test_pattern',
       'test_description_comment',
       'region'
     ]
@@ -114,6 +116,7 @@ RSpec.describe Variable, type: :model do
         'test_description',
         'test_password',
         'test_options',
+        'test_pattern',
         'test_description_comment',
         'region',
         'name',


### PR DESCRIPTION
Implement client side variable validation using the pattern option:

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern

It adds 2 new options to configure the variables using the description entry;

`[title:my variable title`
`[pattern:[mypattern]:endpattern]`

I have not found a better way to encapsulate the pattern option without the `endpattern` keyword, as the patterns might have several `[]` (even nested ones).


![blue-horizon-validation](https://user-images.githubusercontent.com/36370954/97154858-c1342f80-1774-11eb-9c13-780b06d58c56.gif)
