### PR TITLE
simplify test setup and teardown

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -49,15 +49,16 @@ module Helpers
     end.flatten
   end
 
-  def random_export_path
-    random_path = Rails.root.join('tmp', Faker::File.dir(segment_count: 1))
-    Rails.configuration.x.source_export_dir = random_path
-    FileUtils.mkdir_p(random_path)
-    return random_path
+  def set_export_path
+    Rails.configuration.x.source_export_dir = Rails.root.join('tmp', 'test-run')
   end
 
-  def cleanup_random_export_path
+  def cleanup_export_path
     FileUtils.rm_rf(Rails.configuration.x.source_export_dir)
+  end
+
+  def make_export_path
+    FileUtils.mkdir_p(Rails.configuration.x.source_export_dir)
   end
 
   def working_path
@@ -73,10 +74,8 @@ RSpec.configure do |config|
   config.include Helpers
 
   config.before do
-    random_export_path
-  end
-
-  config.after do
-    cleanup_random_export_path
+    set_export_path
+    cleanup_export_path
+    make_export_path
   end
 end


### PR DESCRIPTION
This PR proposes a simplification of the RSpec setup.

To allow for inspection of test artifacts after a possibly failed test, the removal of the temporary directory is now performed in the setup phase rather than in the teardown. This required to set the configuration key in a separate step.
In addition to this, the temporary test directory is no longer randomly generated (I couldn't see any reason for this to be actually needed).