### PR TITLE
Fix Travis runs when sources are present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ before_install:
   - curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_linux_amd64.zip
   - unzip /tmp/terraform.zip -d /tmp
   - mv /tmp/terraform ~/bin
-before_script:
-  - RAILS_ENV=test bundle exec rails db:setup
 jobs:
   include:
     - name: "specs"


### PR DESCRIPTION
I noticed in our own fork (where we have terraform sources commited in) that setting up the database before the tests will break the entire build.

Was this step needed in the first place? As far as I could understand, fixtures are imported by the rspec helpers anyway.