### PR TITLE
Enable HTML tags usage in markdown content

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,7 +53,7 @@ module ApplicationHelper
       quote:               true
     }
     render_options = {
-      filter_html: true,
+      filter_html: false,
       no_images:   true,
       no_styles:   true
     }


### PR DESCRIPTION
Disable html filtering in the markdown render process.

Besides that, I have added an empty vendor stylesheet to use from the vendor folder without modifying the `application.css` file. I don't know if there is a better option, but I have not found it.

This allows markdown entries with html tags. 
Example:
![collapsable](https://user-images.githubusercontent.com/36370954/98812094-2ac56680-2422-11eb-973c-267affe738ce.gif)

`vendor_custom.css` is modified with the next content to apply new styles to markdown html tags:
```
summary.welcome {
  background: #333;
  color: #FFF;
  border-radius: 3px;
  padding: 5px 10px;
  outline: none;
}

/* Style the summary when details box is open */
details[open] summary.welcome {
  background: #30ba78;
  color: #333;
}
```