### PR TITLE
Support a vendor-provided custom view helper module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ public/dev-assets/*
 vendor/customization.json
 vendor/data/*
 !vendor/data/.keep
+vendor/lib/*
+!vendor/lib/.keep
 vendor/locales/*
 !vendor/locales/.keep
 vendor/sources/*

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ To use a different path, set the environment variable `BLUE_HORIZON_CUSTOMIZER` 
 
 Any view or partial view (see `app/views`) can be overridden with an application-specific view. Set the configuration option `"override_views": true`, then copy the original to `vendor/views`, (e.g. `app/views/plans/_plan.haml` to `vendor/views/plans/_plan.haml`) and make your customizations in the copy.
 
+#### View helpers
+
+Any custom helper methods required by custom views should be defined as methods of the `CustomHelpers` module, in the file `vendor/lib/custom_helpers.rb`. If this file is present, the helpers will be loaded and available to the view rendering pipeline.
+
+⚠ *Please be careful of naming conflicts, as all helpers are effectively in the same namespace.*
+
 #### Top menu items
 
 A a group of custom top-menu links can be added to application views. If the links use *terraform* outputs, they will only be enabled on the `/wrapup` (*Next steps*) page. Links may open in the same browser context, or request a new tab/window.

--- a/config/initializers/customization.rb
+++ b/config/initializers/customization.rb
@@ -49,3 +49,9 @@ end
 require 'fileutils'
 
 FileUtils.mkdir_p(Rails.configuration.x.source_export_dir)
+
+helpers_filepath = Rails.root.join('vendor', 'lib', 'custom_helpers.rb')
+if File.exist?(helpers_filepath)
+  require helpers_filepath
+  ActiveSupport.on_load(:action_view) { include CustomHelpers }
+end


### PR DESCRIPTION
`CustomHelpers` module, defined in `vendor/lib/custom_helpers.rb` will be added to the `ActionView` load path.