### PR TITLE
Enable option to use local images in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ To use a different path, set the environment variable `BLUE_HORIZON_CUSTOMIZER` 
 
 Any view or partial view (see `app/views`) can be overridden with an application-specific view. Set the configuration option `"override_views": true`, then copy the original to `vendor/views`, (e.g. `app/views/plans/_plan.haml` to `vendor/views/plans/_plan.haml`) and make your customizations in the copy.
 
+### Images in markdown
+
+To add local images in markdown, follow the next syntax (in the `custom-en.yml` for example):
+
+```
+# Image in vendor/assets/images/local.png
+![image]("asset_path=local.png")
+
+# Or in html tags
+<img src="asset_path=local.png" width="100" heigh="100">
+```
+
 #### Top menu items
 
 A a group of custom top-menu links can be added to application views. If the links use *terraform* outputs, they will only be enabled on the `/wrapup` (*Next steps*) page. Links may open in the same browser context, or request a new tab/window.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,14 +54,19 @@ module ApplicationHelper
     }
     render_options = {
       filter_html: true,
-      no_images:   true,
+      no_images:   false,
       no_styles:   true
     }
     render_options[:escape_html] = true if escape_html
 
+    # Get assets path
+    text_with_assets = text.gsub(/"asset_path=(.*?)"/) do
+      asset_path("#{$1}")
+    end
+
     # Redcarpet doesn't remove HTML comments even with `filter_html: true`
     # https://github.com/vmg/redcarpet/issues/692
-    uncommented_text = text.gsub(/<!--(.*?)-->/, '')
+    uncommented_text = text_with_assets.gsub(/<!--(.*?)-->/, '')
 
     markdown = Redcarpet::Markdown.new(
       Redcarpet::Render::HTML.new(render_options),


### PR DESCRIPTION
We will want to add some images in markdown first/last pages to improve the information we want to provide the users.

Local images from `/vendor/assets/images` can be loaded like:
```
# Image in vendor/assets/images/local.png
![image]("asset_path=local.png")
# Or in html tags
<img src="asset_path=local.png" width="100" heigh="100">
```
 Example:
![image](https://user-images.githubusercontent.com/36370954/98922007-3cfedd80-24d2-11eb-83f9-55f3d01686fc.png)

