### PR TITLE
Allow vendored images

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ See `config/locales/custom-en.yml` for a sample/template with keys defined.
 
 To use a different path, set the environment variable `BLUE_HORIZON_LOCALIZERS` with the directory where custom internationalization files are stored.
 
+#### Markdown
+
+The internationalization content `description` and `next_steps`, shown on the first and last pages, respectively, allow _markdown_ content. It is recommended for readability and maintenance, to define these as multiline YAML. The following special features are supported:
+
+* **inline HTML**: in the event that _markdown_ is insufficient for content, raw HTML may be defined. Please be sure to parse any inline HTML as valid with an external parser.
+* **images**: images may be included using the standard _markdown_ format. Image files should be placed in `vendor/assets/images` and referred to in _mardown_ with the path `/vendor/NAME_OF_IMAGE`. For example, given an image stored as `vendor/assets/images/design.png`, the _markdown_ syntax to include it is:
+
+  ```
+  ![design](/vendor/design.png)
+  ```
+
+  ⚠ *Images included in markdown will not be versioned by the Rails asset pipeline, so be aware of possible caching issues.*
+
+Please see https://www.markdownguide.org/basic-syntax for more _markdown_ examples.
+
 #### Including *terraform* output in *Next steps*
 
 The `next_steps` content, presented on the last page after deployment, can include terraform outputs. Put a placeholder in the content in the format `%{OUTPUT_NAME}`.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,7 @@ module ApplicationHelper
     }
     render_options = {
       filter_html: false,
-      no_images:   true,
+      no_images:   false,
       no_styles:   true
     }
     render_options[:escape_html] = true if escape_html

--- a/public/vendor
+++ b/public/vendor
@@ -1,0 +1,1 @@
+../vendor/assets/images/


### PR DESCRIPTION
* use standard markdown syntax
* bypass asset pipeline via `public/` symlink