### PR TITLE
Fix to manage properly the terraform stdout content in the progress bar

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -83,7 +83,7 @@ class DeploysController < ApplicationController
 
     created_resources = content.scan(/Creation complete after/).size
     planned_resources_count = KeyValue.get(:planned_resources_count)
-    text = if !error.nil?
+    text = if error.present?
       t('deploy.failed')
     elsif created_resources == planned_resources_count
       t('deploy.finished')

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -29,7 +29,10 @@ class DeploysController < ApplicationController
       success = content.include? 'Apply complete!'
     end
 
-    progress = update_terraform_progress(content, error)
+    progress = {}
+    if Terraform.stdout.is_a?(StringIO)
+      progress = update_terraform_progress(Terraform.stdout.string, error)
+    end
 
     if success
       write_output(content, success)
@@ -76,9 +79,13 @@ class DeploysController < ApplicationController
 
   def update_terraform_progress(content, error)
     progress = {}
+    return progress if content.blank?
+
     created_resources = content.scan(/Creation complete after/).size
     planned_resources_count = KeyValue.get(:planned_resources_count)
-    text = if created_resources == planned_resources_count
+    text = if !error.nil?
+      t('deploy.failed')
+    elsif created_resources == planned_resources_count
       t('deploy.finished')
     else
       t('deploy.creating')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,3 +123,4 @@ en:
     infra_label: "Infrastructure creation"
     creating: "Creating resources..."
     finished: "Finished"
+    failed: "Failed"

--- a/spec/controllers/deploys_controller_spec.rb
+++ b/spec/controllers/deploys_controller_spec.rb
@@ -159,6 +159,28 @@ RSpec.describe DeploysController, type: :controller do
     )
   end
 
+  it 'updates the terraform progress blank content' do
+    KeyValue.set(:planned_resources_count, 10)
+    progress = example.send(:update_terraform_progress, '', nil)
+    expect(progress).to eq({})
+
+    progress = example.send(:update_terraform_progress, nil, nil)
+    expect(progress).to eq({})
+  end
+
+  it 'updates the terraform progress with failed' do
+    KeyValue.set(:planned_resources_count, 5)
+    progress = example.send(:update_terraform_progress, deploy_output, 'error')
+
+    expect(progress).to eq(
+      'infra-bar' => {
+        progress: 100,
+        text:     'Failed',
+        success:  false
+      }
+    )
+  end
+
   it 'updates the terraform progress with finished' do
     KeyValue.set(:planned_resources_count, 5)
     progress = example.send(:update_terraform_progress, deploy_output, nil)

--- a/spec/controllers/deploys_controller_spec.rb
+++ b/spec/controllers/deploys_controller_spec.rb
@@ -93,14 +93,20 @@ RSpec.describe DeploysController, type: :controller do
 
       get :send_current_status, format: :json
 
+      expect(controller).to(
+        have_received(:update_terraform_progress)
+          .with('hello world! Apply complete!', nil)
+            .at_least(:once)
+      )
+
       expect(response).to be_success
     end
 
     it 'can show error output when deploy fails' do
       allow(JSON).to receive(:parse).and_return(foo: 'bar')
 
-      allow(Terraform).to receive(:stderr).and_return(StringIO.new("Error\n"))
-      allow(Terraform).to receive(:stdout).and_return(StringIO.new)
+      allow(Terraform).to receive(:stderr).and_return(StringIO.new('Error'))
+      allow(Terraform).to receive(:stdout).and_return(StringIO.new('Creating'))
 
       allow(controller).to(
         receive(:update_terraform_progress)
@@ -108,6 +114,12 @@ RSpec.describe DeploysController, type: :controller do
       )
 
       get :send_current_status, format: :json
+
+      expect(controller).to(
+        have_received(:update_terraform_progress)
+          .with('Creating', 'Error')
+            .at_least(:once)
+      )
 
       expect(response).to be_success
     end


### PR DESCRIPTION
Fix to manage properly the terraform stdout content.

- In the case of an error, the `content` was set with the error message, so it was not getting the correct data to create the progress information. Besides that, the text for failed scenario was not set.

- Rarely, the terraform stdout was coming with `nil` value. The `blank` method adds a safe guard to that scenario, returning an empty progress information.