### PR TITLE
Correct password show/hide icon styles

### DIFF
--- a/app/assets/javascripts/variables.js
+++ b/app/assets/javascripts/variables.js
@@ -12,20 +12,20 @@ $(function() {
     }
   });
   // Show/hide passwords
-  $("button.peek").click(function() {
+  $(".peek").click(function() {
     var group = $(this).closest(".input-group");
     $(this)
       .hide()
       .tooltip("hide");
-    group.find("button.unpeek").show();
+    group.find(".unpeek").show();
     group.find("input[type='password'").attr("type", "text");
   });
-  $("button.unpeek").click(function() {
+  $(".unpeek").click(function() {
     var group = $(this).closest(".input-group");
     $(this)
       .hide()
       .tooltip("hide");
-    group.find("button.peek").show();
+    group.find(".peek").show();
     group.find("input[type='text'").attr("type", "password");
   });
 });

--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -50,6 +50,14 @@ i.eos-icons.no-trailing-space {
   margin-right: 0;
 }
 
+.input-group-append.peek, .input-group-append.unpeek {
+    cursor: pointer;
+    position: absolute;
+    top: 6px;
+    z-index: 1000;
+    right: -6px;
+}
+
 .progress span{
     display: block;
     position: absolute;

--- a/app/views/variables/_string.html.haml
+++ b/app/views/variables/_string.html.haml
@@ -15,10 +15,8 @@
       - else
         %input.form-control{ type: fieldtype, name: "variables[#{key}]", value: value, required: @variables.required?(key), pattern: @variables.pattern(key), title: @variables.title(key) }
       - if fieldtype == 'password'
-        %button.btn.btn-sm.btn-secondary.peek{ id: "peek_#{key}", type: 'button', data: { toggle: 'tooltip' }, title: t(:password_show) }
-          &nbsp;
+        %div.input-group-append.peek{ id: "peek_#{key}", data: { toggle: 'tooltip' }, title: t(:password_show) }
           %i.eos-icons.eos-24 visibility
-        %button.btn.btn-sm.btn-secondary.unpeek{ id: "unpeek_#{key}",type: 'button', data: { toggle: 'tooltip' }, title: t(:password_hide), style: "display: none;"}
-          &nbsp;
+        %div.input-group-append.unpeek{ id: "unpeek_#{key}",data: { toggle: 'tooltip' }, title: t(:password_hide), style: "display: none;"}
           %i.eos-icons.eos-24 visibility_off
     = formatted_description(description)


### PR DESCRIPTION
Correct password show/hide styles icon as recommend in the EOS branding:
https://suse.eosdesignsystem.com/form-elements/input-fields

New:
![peek-unpeek](https://user-images.githubusercontent.com/36370954/100844525-439ec600-347c-11eb-80a4-bee5618537cf.gif)

Before:
![image](https://user-images.githubusercontent.com/36370954/100844599-5d400d80-347c-11eb-8c8a-0348623f6aef.png)

