### PR TITLE
Fix plan view authorization

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -8,7 +8,7 @@ class PlansController < ApplicationController
   before_action :variables
 
   def show
-    return unless helpers.can(deploy_path)
+    return unless helpers.can(plan_path)
 
     @trigger_update = (@variables.updated_at > Terraform.last_action_at)
     @plan = ''

--- a/spec/features/plan_spec.rb
+++ b/spec/features/plan_spec.rb
@@ -11,13 +11,16 @@ describe 'planning', type: :feature do
 
   context 'without a current plan' do
     let(:expected_plan_json) { current_plan_fixture_json }
+    let(:terra) { Terraform }
 
     before do
+      allow(terra).to receive(:last_action_at).and_return(-1)
       visit(plan_path)
     end
 
     it 'loads without a pre-generated plan' do
       expect(find('#plan')).to have_no_content
+      expect(page).to have_selector('#loading')
     end
   end
 


### PR DESCRIPTION
Fix the plan view functionality when it is reached the first one.
If we check the `deploy_path` authorization, the loading gif will stay spinning forever