### PR TITLE
Define bundler arguments in travis to avoid deprecated flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 cache: bundler
+bundler_args: --jobs 3 --retry 3
 before_install:
   - curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_linux_amd64.zip
   - unzip /tmp/terraform.zip -d /tmp


### PR DESCRIPTION
Bundler package has been upgraded to `2.2.0` the 10th of December.
https://rubygems.org/gems/bundler/versions/
This has changed our CI and our builds are failing:
https://travis-ci.com/github/SUSE/blue-horizon/jobs/457302257

Changing the bundler arguments to avoid deprecated flags fixes the issue

More info:
https://docs.travis-ci.com/user/languages/ruby/#bundler-20