### PR TITLE
Balance the size of the navigation buttons

### DIFF
--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -58,11 +58,15 @@ i.eos-icons.no-trailing-space {
     right: -6px;
 }
 
-.progress span{
+.progress span {
     display: block;
     position: absolute;
     width: 90%;
     color: black;
+}
+
+.steps-container .btn {
+  min-width: 8em;
 }
 
 // A placeholder for custom CSS.


### PR DESCRIPTION
The nav buttons look wierd to me, now, without the arrows... and I think most of this is the variance in sizes, so I've tried to mitigate that with a little CSS.

Before
![Screenshot_2020-12-16 blue-horizon demo](https://user-images.githubusercontent.com/108494/102379921-373a6300-3f7c-11eb-9096-8d86590f8f48.png)

After
![Screenshot_2020-12-16 blue-horizon demo(1)](https://user-images.githubusercontent.com/108494/102379937-3bff1700-3f7c-11eb-8394-e956cc471d6b.png)
