### PR TITLE
Eliminate unexpected production requirement of nodejs for assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ rubocop
 
 Please be sure to include a screenshot with any view or style changes.
 
+**⚠ NOTE:**  ES6 is not currently usable with this application; please write any JS/ES conforming to ES2015.
+
 ## Customization
 
 _blue-horizon_ is pointless, without a set of terraform scripts to work from, and those scripts represent a "target application", which _blue-horizon_ can adapt to support. The `vendor` path is used by default to host content about the target application.

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -1,50 +1,66 @@
-$(function() {
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+$(function () {
   var intervalId = undefined;
   var finished = false;
+  $("#submit-deploy").bind("ajax:beforeSend", function () {
+    $("#output").text("");
+    $(this).addClass("no-hover");
+    $(".float-right .steps-container .btn").addClass("disabled");
+    $(".list-group-flush a").addClass("disabled");
+    $("#loading").show();
+    $("a[data-toggle]").tooltip("hide");
+    intervalId = setTimeout(function () {
+      fetch_output(finished, intervalId);
+    }, 5000);
+  }).bind("ajax:success", function () {
+    $("#notice").html("<%= flash[:error] %>");
 
-  $("#submit-deploy")
-    .bind("ajax:beforeSend", function() {
-      $("#output").text("");
-      $(this).addClass("no-hover");
-      $(".float-right .steps-container .btn").addClass("disabled");
-      $(".list-group-flush a").addClass("disabled");
-      $("#loading").show();
-      $("a[data-toggle]").tooltip("hide");
-      intervalId = setTimeout(function() {
-        fetch_output(finished, intervalId);
-      }, 5000);
-    })
-    .bind("ajax:success", function() {
-      $("#notice").html("<%= flash[:error] %>");
-      if ($("#output").text().length > 0) {
-        clearTimeout(intervalId);
-      }
-      finished = true;
-    })
-    .bind("ajax:complete", function() {
-      $(this).removeClass("no-hover");
-      if ($("#output").text().length > 0) {
-        clearTimeout(intervalId);
-        finished = true;
-      }
-    })
-    .bind("ajax:error", function() {
-      $("#loading").hide();
+    if ($("#output").text().length > 0) {
       clearTimeout(intervalId);
-    });
+    }
+
+    finished = true;
+  }).bind("ajax:complete", function () {
+    $(this).removeClass("no-hover");
+
+    if ($("#output").text().length > 0) {
+      clearTimeout(intervalId);
+      finished = true;
+    }
+  }).bind("ajax:error", function () {
+    $("#loading").hide();
+    clearTimeout(intervalId);
+  });
 });
 
 function update_progress_bar(progress_data) {
-  Object.entries(progress_data).forEach(entry=>{
-    const [id, bar_data] = entry;
-    const bar_id = "#" + id;
+  Object.entries(progress_data).forEach(function (entry) {
+    var _entry = _slicedToArray(entry, 2),
+        id = _entry[0],
+        bar_data = _entry[1];
+
+    var bar_id = "#" + id;
+
     if ("text" in bar_data) {
       progress_text = bar_data.progress + "% - " + bar_data.text;
     } else {
       progress_text = bar_data.progress + "%";
     }
+
     $(bar_id).css("width", bar_data.progress + "%");
     $(bar_id).find("span").html(progress_text);
+
     if (bar_data.success) {
       if (bar_data.progress < 100) {
         $(bar_id).addClass("progress-bar-striped progress-bar-animated");
@@ -63,13 +79,13 @@ function fetch_output(finished, intervalId) {
     type: "GET",
     url: "deploy/send_current_status",
     dataType: "json",
-    success: function(data) {
+    success: function success(data) {
       if (data.error !== null) {
-        $("#loading").hide();
-        // show rails flash message
+        $("#loading").hide(); // show rails flash message
+
         $("#error_message").text("Deploy operation has failed.");
-        $("#flash").show();
-        // show terraform error message in output section
+        $("#flash").show(); // show terraform error message in output section
+
         $("#output").text($("#output").text() + data.error);
         clearTimeout(intervalId);
         $(".steps-container .btn.disabled").removeClass("disabled");
@@ -78,24 +94,27 @@ function fetch_output(finished, intervalId) {
         // update scrollable
         $(".pre-scrollable").html(data.new_html);
         var autoscroll = $("#deploy_log_autoscroll").prop("checked");
+
         if (autoscroll) {
           $(".pre-scrollable").scrollTop($("#output").height());
         }
+
         if (!finished && !data.success) {
-          intervalId = setTimeout(function() {
+          intervalId = setTimeout(function () {
             fetch_output();
           }, 5000);
         } else {
           $(".steps-container .btn.disabled").removeClass("disabled");
           $("#loading").hide();
         }
-      }
-      // update progress bar
+      } // update progress bar
+
+
       if ("progress" in data) {
-        update_progress_bar(data.progress)
+        update_progress_bar(data.progress);
       }
     },
-    error: function(data) {
+    error: function error(data) {
       var endIndex = data.responseText.indexOf("#");
       if (endIndex == -1) endIndex = data.responseText.indexOf("\n");
       $("#error_message").text(data.responseText.substring(0, endIndex));
@@ -104,8 +123,7 @@ function fetch_output(finished, intervalId) {
       $("#loading").hide();
     }
   });
-
-  $("#flash .close").click(function() {
+  $("#flash .close").click(function () {
     $("#flash").hide();
   });
 }

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,265 +1,263 @@
 /* Return TRUE/FALSE base on windows size.
 ========================================================================== */
-const isSmallScreen = () => {
-  return window.innerWidth <= 1260
-}
-
+var isSmallScreen = function isSmallScreen() {
+  return window.innerWidth <= 1260;
+};
 /* ==========================================================================
   Collapse funtionality
   ========================================================================== */
-const collapseSidebarOnSmallScreen = () => {
+
+
+var collapseSidebarOnSmallScreen = function collapseSidebarOnSmallScreen() {
   if (isSmallScreen()) {
     // in small screen the menu starts collapsed
-    $('.js-main-menu').addClass('collapsed-sidebar')
-    $('.js-footer-content').addClass('display-collapsed')
-    // return true to initiate the tooltip
-    window.localStorage.setItem('collapsedSidebar', $('.js-main-menu').hasClass('collapsed-sidebar'))
-    return true
-  }
-}
+    $('.js-main-menu').addClass('collapsed-sidebar');
+    $('.js-footer-content').addClass('display-collapsed'); // return true to initiate the tooltip
 
-const collapseSidebarBasedOnLocalStorage = () => {
+    window.localStorage.setItem('collapsedSidebar', $('.js-main-menu').hasClass('collapsed-sidebar'));
+    return true;
+  }
+};
+
+var collapseSidebarBasedOnLocalStorage = function collapseSidebarBasedOnLocalStorage() {
   if (window.localStorage.getItem('collapsedSidebar') === 'true') {
     // if saved in locastorage that collapsedSidebar=true, menu starts collapsed
-    $('.js-main-menu').addClass('collapsed-sidebar')
-    // return true to initiate the tooltip
-    return true
+    $('.js-main-menu').addClass('collapsed-sidebar'); // return true to initiate the tooltip
+
+    return true;
   }
-}
+};
 
-const toggleSidebarAndSave = () => {
-  $('.js-main-menu').toggleClass('collapsed-sidebar')
-  $('.js-footer-content').toggleClass('display-collapsed')
-
-  toggleTooltip()
+var toggleSidebarAndSave = function toggleSidebarAndSave() {
+  $('.js-main-menu').toggleClass('collapsed-sidebar');
+  $('.js-footer-content').toggleClass('display-collapsed');
+  toggleTooltip();
 
   if (!isSmallScreen()) {
-    saveSidebarState()
+    saveSidebarState();
   }
-}
+};
 
-const autoToggleSidebar = () => {
-  const shouldCollapse = isSmallScreen() || window.localStorage.getItem('collapsedSidebar') === 'true'
+var autoToggleSidebar = function autoToggleSidebar() {
+  var shouldCollapse = isSmallScreen() || window.localStorage.getItem('collapsedSidebar') === 'true';
+  toggleTooltip();
+  $('.js-main-menu').toggleClass('collapsed-sidebar', shouldCollapse);
+  $('.js-footer-content').toggleClass('display-collapsed', shouldCollapse);
+};
 
-  toggleTooltip()
+var saveSidebarState = function saveSidebarState() {
+  window.localStorage.setItem('collapsedSidebar', $('.js-main-menu').hasClass('collapsed-sidebar'));
+}; // Initiate or destroy the tooltip according to the state of the collapsible menu
 
-  $('.js-main-menu').toggleClass('collapsed-sidebar', shouldCollapse)
-  $('.js-footer-content').toggleClass('display-collapsed', shouldCollapse)
-}
 
-const saveSidebarState = () => {
-  window.localStorage.setItem('collapsedSidebar', $('.js-main-menu').hasClass('collapsed-sidebar'))
-}
-
-// Initiate or destroy the tooltip according to the state of the collapsible menu
-const toggleTooltip = () => {
+var toggleTooltip = function toggleTooltip() {
   // if the menu is not collapsed (meaning, it is open) we dont need to show the tooltips
   if ($('.collapsed-sidebar').length === 0) {
-    $('.js-sidebar-tooltip').attr('data-original-title', 'Collapse menu')
+    $('.js-sidebar-tooltip').attr('data-original-title', 'Collapse menu');
   } else {
     // If sidebar is collapsed update sidebar toggle btn tooltip title
-    $('.js-sidebar-tooltip').attr('data-original-title', 'Open menu')
+    $('.js-sidebar-tooltip').attr('data-original-title', 'Open menu');
   }
-}
+}; // Togle on resize and click.
 
-// Togle on resize and click.
-$(window).resize(autoToggleSidebar)
-$(document).on('click', '.js-sidebar-toggle', toggleSidebarAndSave)
 
-// When the page is done loading, check if we should toggle the menu based on width or localstorage
-$(document).ready(() => {
+$(window).resize(autoToggleSidebar);
+$(document).on('click', '.js-sidebar-toggle', toggleSidebarAndSave); // When the page is done loading, check if we should toggle the menu based on width or localstorage
+
+$(document).ready(function () {
   if (window.localStorage.getItem('collapsedSidebar') === 'true') {
     // Always display content-footer if showSidebar === false
-    $('.js-footer-content').addClass('display-collapsed')
-    // If sidebar is collapsed update sidebar toggle btn tooltip title
-    $('.js-sidebar-tooltip').attr('data-original-title', 'Open menu')
-  }
-  // If sidebar isn't collapsed update sidebar toggle btn tooltip title
+    $('.js-footer-content').addClass('display-collapsed'); // If sidebar is collapsed update sidebar toggle btn tooltip title
+
+    $('.js-sidebar-tooltip').attr('data-original-title', 'Open menu');
+  } // If sidebar isn't collapsed update sidebar toggle btn tooltip title
+
+
   if (window.localStorage.getItem('collapsedSidebar') === 'false') {
-    $('.js-sidebar-tooltip').attr('data-original-title', 'Collapse menu')
-  }
-
-  // if either the screen is small or it is saved in localstorage to keep the menu open
+    $('.js-sidebar-tooltip').attr('data-original-title', 'Collapse menu');
+  } // if either the screen is small or it is saved in localstorage to keep the menu open
   // then we Initiate the tooltip
-  if (collapseSidebarOnSmallScreen() || collapseSidebarBasedOnLocalStorage()) {
-    toggleTooltip()
-  }
 
+
+  if (collapseSidebarOnSmallScreen() || collapseSidebarBasedOnLocalStorage()) {
+    toggleTooltip();
+  }
   /* ==========================================================================
   Menu collapse funtionality for mobile
   ========================================================================== */
+
   /* Select the mobile menu elements */
-  const mobileMenu = $('.js-mobile-menu').find('nav')
+
+
+  var mobileMenu = $('.js-mobile-menu').find('nav');
   /* Toggle mobile menu on click */
-  $('.js-burger-menu').click(() => {
-    mobileMenu.slideToggle()
-    $('body').toggleClass('mobile-menu-open')
-  })
 
-  showCollpasedMenuFloatingItems()
-})
+  $('.js-burger-menu').click(function () {
+    mobileMenu.slideToggle();
+    $('body').toggleClass('mobile-menu-open');
+  });
+  showCollpasedMenuFloatingItems();
+});
 
-const showCollpasedMenuFloatingItems = () => {
+var showCollpasedMenuFloatingItems = function showCollpasedMenuFloatingItems() {
   $('.menu-item').on('mouseover', function () {
-    const $menuItem = $(this)
-    const $collapsedTitle = $('> .menu-element', $menuItem)
+    var $menuItem = $(this);
+    var $collapsedTitle = $('> .menu-element', $menuItem);
+    var menuItemPos = $menuItem.position(); // nav height to position dropdown menu from bottom
 
-    const menuItemPos = $menuItem.position()
+    var navHeight = $('.nav-wrap').height();
+    var finalDropdownPos = navHeight - menuItemPos.top; // Dropdown height and calculate bottom height + extra px for margin
 
-    // nav height to position dropdown menu from bottom
-    const navHeight = $('.nav-wrap').height()
-    const finalDropdownPos = navHeight - menuItemPos.top
-
-    // Dropdown height and calculate bottom height + extra px for margin
-    const windowHeight = $('.main-menu').height()
-    const dropdownHeight = $('> .menu-element', $menuItem).height()
-    const bottomHeight = Math.round(windowHeight - menuItemPos.top) - 70
+    var windowHeight = $('.main-menu').height();
+    var dropdownHeight = $('> .menu-element', $menuItem).height();
+    var bottomHeight = Math.round(windowHeight - menuItemPos.top) - 70;
 
     if (dropdownHeight < bottomHeight) {
       $collapsedTitle.css({
         'bottom': 'auto',
         'top': menuItemPos.top,
         'left': $menuItem.hasClass('menu-dropdown') ? menuItemPos.left + Math.round($menuItem.outerWidth() * 1) : 0
-      })
+      });
     } else {
       $collapsedTitle.css({
         'bottom': $menuItem.hasClass('menu-dropdown') ? finalDropdownPos - 37 : finalDropdownPos,
         'top': 'auto',
         'left': $menuItem.hasClass('menu-dropdown') ? menuItemPos.left + Math.round($menuItem.outerWidth() * 1) : 0
-      })
+      });
     }
-  })
-}
+  });
+};
 
 $(function () {
   /* Menu elements limit, we need to pass it here for the resize event to work */
-  const limit = $(window).innerWidth > 1300 ? 7 : 4
+  var limit = $(window).innerWidth > 1300 ? 7 : 4;
   /* When window is resized, run our collapse function */
-  $(window).resize(submenuCollapse(limit))
+
+  $(window).resize(submenuCollapse(limit));
   /* On scroll, call submenuAddShadow */
-  $(document).scroll(submenuAddShadow)
+
+  $(document).scroll(submenuAddShadow);
   /* When window loads, if current the page is inside the dropdown, then highlight more menu */
-  submenuCollapse()
 
-  $('.js-sidebar-toggle').click(() => {
-    submenuCollapse()
-  })
-})
-
+  submenuCollapse();
+  $('.js-sidebar-toggle').click(function () {
+    submenuCollapse();
+  });
+});
 /* ==========================================================================
   Menu collapse function
   ========================================================================== */
+
 /* Maximum number of elements allowed in the menu  */
 
 /*
   by default the limit is 7, unless an argument is passed.
   This is necessary to unit test this component
 */
-const submenuCollapse = (limit = 7) => {
+
+var submenuCollapse = function submenuCollapse() {
+  var limit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 7;
+
   /* Highlight more menu, if current the page is inside the dropdown */
-  highlightMoreMenu()
-
+  highlightMoreMenu();
   /* Get each nav element's width and set it as attribute to be used later */
-  submenuLinksSetAttribute()
 
+  submenuLinksSetAttribute();
   /* Display dropdown in left/right based on windows size */
-  submenuDropdownPosition()
 
-  const collapsedSidebarStatus = $('.js-main-menu').hasClass('collapsed-sidebar')
-
-  const submenuLimit = limit
-  const submenuLinks = $('.js-submenu-visible > .js-select-current')
-  const submenuMore = $('.js-submenu-more')
-
-  let navWidth = 0
-  const submenuMoreContent = $('.js-submenu-more-list')
-  let submenuWidth = $('.js-submenu-section').width()
-  let submenuLinksCheck
+  submenuDropdownPosition();
+  var collapsedSidebarStatus = $('.js-main-menu').hasClass('collapsed-sidebar');
+  var submenuLimit = limit;
+  var submenuLinks = $('.js-submenu-visible > .js-select-current');
+  var submenuMore = $('.js-submenu-more');
+  var navWidth = 0;
+  var submenuMoreContent = $('.js-submenu-more-list');
+  var submenuWidth = $('.js-submenu-section').width();
+  var submenuLinksCheck;
 
   if (collapsedSidebarStatus && $(window).innerWidth() > 754) {
-    submenuWidth = submenuWidth - 190
+    submenuWidth = submenuWidth - 190;
   }
-
   /* Cleanup dom when resizing */
-  submenuMoreContent.html('')
 
+
+  submenuMoreContent.html('');
   /* 'smart' responsiveness */
+
   submenuLinks.each(function (index) {
     // Use the width data attr we setup before
-    navWidth += $(this).data('width')
+    navWidth += $(this).data('width'); // Possible combination of elements
 
-    // Possible combination of elements
-    const moreSearchWidth = $('.js-submenu-more').outerWidth() + $('.submenu-search').outerWidth()
-    const moreUserWidth = $('.js-submenu-more').outerWidth() + $('.js-user-profile').outerWidth()
-    const combinedWidth = $('.js-submenu-more').outerWidth() + $('.submenu-search').outerWidth() + $('.js-user-profile').outerWidth()
+    var moreSearchWidth = $('.js-submenu-more').outerWidth() + $('.submenu-search').outerWidth();
+    var moreUserWidth = $('.js-submenu-more').outerWidth() + $('.js-user-profile').outerWidth();
+    var combinedWidth = $('.js-submenu-more').outerWidth() + $('.submenu-search').outerWidth() + $('.js-user-profile').outerWidth(); // Cache conditions for readability
 
-    // Cache conditions for readability
-    const condLimit = index > submenuLimit - 1
-    // Default condition (no search or user)
-    const condDefault = navWidth > submenuWidth - 70
-    // More dropdown & search
-    const condMoreSearch = navWidth > submenuWidth - moreSearchWidth
-    // More dropdown & user
-    const condMoreUser = navWidth > submenuWidth - moreUserWidth
-    // All dropdowns
-    const condCombined = navWidth > submenuWidth - combinedWidth
+    var condLimit = index > submenuLimit - 1; // Default condition (no search or user)
 
-    // If any of these conditions are met
+    var condDefault = navWidth > submenuWidth - 70; // More dropdown & search
+
+    var condMoreSearch = navWidth > submenuWidth - moreSearchWidth; // More dropdown & user
+
+    var condMoreUser = navWidth > submenuWidth - moreUserWidth; // All dropdowns
+
+    var condCombined = navWidth > submenuWidth - combinedWidth; // If any of these conditions are met
+
     if (condLimit || condDefault || condMoreSearch || condMoreUser || condCombined) {
       // Hide the nav item
-      $(this).addClass('d-none')
-      // Clone it, strip it from any class and move it to the dropdown
-      $(this).clone().removeClass('d-none submenu-item').addClass('dropdown-item').appendTo(submenuMoreContent)
-      // Show the dropdown
-      submenuMore.show()
-      submenuLinksCheck = true
+      $(this).addClass('d-none'); // Clone it, strip it from any class and move it to the dropdown
+
+      $(this).clone().removeClass('d-none submenu-item').addClass('dropdown-item').appendTo(submenuMoreContent); // Show the dropdown
+
+      submenuMore.show();
+      submenuLinksCheck = true;
     } else {
       // If none of these conditions are met, ensure that we show the nav items
-      $(this).removeClass('d-none')
+      $(this).removeClass('d-none');
     }
-  })
+  }); // If the amount of nav items is greater than 7 or check if all conditions are met, display the dropdown
 
-  // If the amount of nav items is greater than 7 or check if all conditions are met, display the dropdown
   if (submenuLinks.length > submenuLimit || submenuLinksCheck) {
-    submenuMore.show()
+    submenuMore.show();
   } else {
-    submenuMore.hide()
+    submenuMore.hide();
   }
-}
+};
 
-const submenuDropdownPosition = () => {
-  const _selector = $('.js-submenu-section').innerWidth()
+var submenuDropdownPosition = function submenuDropdownPosition() {
+  var _selector = $('.js-submenu-section').innerWidth();
 
-  return _selector <= 1360
-    ? $('.js-submenu-content').removeClass('dropdown-menu-left').addClass('dropdown-menu-right')
-    : $('.js-submenu-content').removeClass('dropdown-menu-right').addClass('dropdown-menu-left')
-}
-
+  return _selector <= 1360 ? $('.js-submenu-content').removeClass('dropdown-menu-left').addClass('dropdown-menu-right') : $('.js-submenu-content').removeClass('dropdown-menu-right').addClass('dropdown-menu-left');
+};
 /* Add data-width attr to navigation elements  */
-function submenuLinksSetAttribute () {
+
+
+function submenuLinksSetAttribute() {
   $('.js-submenu-visible > .js-select-current').each(function () {
-    $(this).attr('data-width', $(this).outerWidth())
-  })
+    $(this).attr('data-width', $(this).outerWidth());
+  });
 }
-
 /* Add shadow to submenu element on scrop */
-const submenuAddShadow = () => {
-  if ($(window).scrollTop() > 100) {
-    $('.js-submenu-section').stop().addClass('submenu-scroll')
-  } else {
-    $('.js-submenu-section').stop().removeClass('submenu-scroll')
-  }
-}
 
-/* When window loads, if current the page is inside the dropdown, then highlight more menu */
-const highlightMoreMenu = () => {
-  const $selectedSubItem = $('.js-submenu-more-list').find('.selected').length
-  if ($selectedSubItem === 1) {
-    $('.js-submenu-more .submenu-item').addClass('selected')
+
+var submenuAddShadow = function submenuAddShadow() {
+  if ($(window).scrollTop() > 100) {
+    $('.js-submenu-section').stop().addClass('submenu-scroll');
   } else {
-    $('.js-submenu-more .submenu-item').removeClass('selected')
+    $('.js-submenu-section').stop().removeClass('submenu-scroll');
   }
-}
+};
+/* When window loads, if current the page is inside the dropdown, then highlight more menu */
+
+
+var highlightMoreMenu = function highlightMoreMenu() {
+  var $selectedSubItem = $('.js-submenu-more-list').find('.selected').length;
+
+  if ($selectedSubItem === 1) {
+    $('.js-submenu-more .submenu-item').addClass('selected');
+  } else {
+    $('.js-submenu-more .submenu-item').removeClass('selected');
+  }
+};
 
 $(function () {
   /*
@@ -268,23 +266,22 @@ $(function () {
     it will check if `href = path` matches with the current path
     in the URL, and if it does, the item will get the class `.selected`
    */
-
   $('.js-select-current').addClass(function () {
-    const itemRoute = $(this).attr('href')
-    const itemRouteNew = window.location.pathname
-    const itemRouteSplit = itemRouteNew.split('/')
+    var itemRoute = $(this).attr('href');
+    var itemRouteNew = window.location.pathname;
+    var itemRouteSplit = itemRouteNew.split('/');
 
     if (itemRouteSplit.length > 3) {
-      itemRouteSplit.pop()
+      itemRouteSplit.pop();
     }
-    const windowLocation = itemRouteSplit.join('/')
-    return windowLocation === itemRoute ? 'selected' : ''
-  })
 
+    var windowLocation = itemRouteSplit.join('/');
+    return windowLocation === itemRoute ? 'selected' : '';
+  });
   $('.js-select-submenu').addClass(function () {
-    const itemRoute = $(this).attr('href')
-    return window.location.pathname === itemRoute ? 'selected' : ''
-  })
+    var itemRoute = $(this).attr('href');
+    return window.location.pathname === itemRoute ? 'selected' : '';
+  });
   /*
     Use this as follows:
     Add the class .js-select-current-parent to the link you want to select.
@@ -294,23 +291,22 @@ $(function () {
     the item will get the class `.selected`, but if the href was `/foo/bar`
     then it will be skipped and not be selected.
    */
+
   $('.js-select-current-parent').addClass(function () {
-    const itemRoute = $(this).attr('href').replace('/', '')
-    const currentRoute = window.location.pathname
-    const currentRouteParent = currentRoute.split('/')
-    return itemRoute === currentRouteParent[1] ? 'selected' : ''
-  })
+    var itemRoute = $(this).attr('href').replace('/', '');
+    var currentRoute = window.location.pathname;
+    var currentRouteParent = currentRoute.split('/');
+    return itemRoute === currentRouteParent[1] ? 'selected' : '';
+  });
+  makeSubmenuSectionVisible(submenuCollapse, submenuDropdownPosition); // eslint-disable-line no-undef
 
-  makeSubmenuSectionVisible(submenuCollapse, submenuDropdownPosition) // eslint-disable-line no-undef
-  $(window).resize(fn => {
-    makeSubmenuSectionVisible(submenuCollapse, submenuDropdownPosition)// eslint-disable-line no-undef
-  })
+  $(window).resize(function (fn) {
+    makeSubmenuSectionVisible(submenuCollapse, submenuDropdownPosition); // eslint-disable-line no-undef
+  }); // Call the dropdown function
 
-  // Call the dropdown function
-  selectedDropdown()
-  selectedDropdownMobile()
-})
-
+  selectedDropdown();
+  selectedDropdownMobile();
+});
 /*
   Use this as follows:
   Add the class .js-submenu-make-visible to the submenu nav you want to make visible.
@@ -321,124 +317,121 @@ $(function () {
   then it will stay hidden.
  */
 
-const makeSubmenuSectionVisible = (submenu, submenuDopDown) => {
+var makeSubmenuSectionVisible = function makeSubmenuSectionVisible(submenu, submenuDopDown) {
   $('.js-submenu-make-visible').addClass(function () {
-    const pm = $(this).data('parent-menu') // pm => parent menu
-    const currentRoute = window.location.pathname
-    const currentRouteParent = currentRoute.split('/')
-    const pmSplit = pm.split('/')
-    submenuDopDown()
-    submenu()
+    var pm = $(this).data('parent-menu'); // pm => parent menu
 
-    const newCurrentParent = currentRouteParent.slice(1, 3).join('/')
+    var currentRoute = window.location.pathname;
+    var currentRouteParent = currentRoute.split('/');
+    var pmSplit = pm.split('/');
+    submenuDopDown();
+    submenu();
+    var newCurrentParent = currentRouteParent.slice(1, 3).join('/');
 
     if (currentRouteParent.length > 2 && pmSplit.length > 1) {
-      return pm === newCurrentParent ? 'visible js-submenu-visible' : ''
+      return pm === newCurrentParent ? 'visible js-submenu-visible' : '';
     } else {
-      return pm === currentRouteParent[1] ? 'visible js-submenu-visible' : ''
+      return pm === currentRouteParent[1] ? 'visible js-submenu-visible' : '';
     }
-  })
-}
-
+  });
+};
 /* Find if an element inside the menu dropdown list is active and leave the dropdown open */
-const selectedDropdown = () => {
+
+
+var selectedDropdown = function selectedDropdown() {
   /* Big screen dropdown open */
-  const $selectedSub = $('.menu-dropdown-list').find('a.selected')[0]
-  $($selectedSub).parents('.menu-dropdown').addClass('selected')
-  $($selectedSub).closest('.menu-dropdown-list').siblings('.js-dropdown-toggle').prop('checked', true)
-}
+  var $selectedSub = $('.menu-dropdown-list').find('a.selected')[0];
+  $($selectedSub).parents('.menu-dropdown').addClass('selected');
+  $($selectedSub).closest('.menu-dropdown-list').siblings('.js-dropdown-toggle').prop('checked', true);
+};
 
-const selectedDropdownMobile = () => {
+var selectedDropdownMobile = function selectedDropdownMobile() {
   /* Mobile dropdown open */
-  const $menuDropdownMobile = $('.js-mobile-menu .menu-dropdown')
-  const $selectedSubMobile = $('.js-mobile-menu .menu-dropdown').find('.selected')[0]
+  var $menuDropdownMobile = $('.js-mobile-menu .menu-dropdown');
+  var $selectedSubMobile = $('.js-mobile-menu .menu-dropdown').find('.selected')[0];
 
-  for (let i = 0; i < $menuDropdownMobile.length; i++) {
-    $($selectedSubMobile).parents('.menu-dropdown').addClass('selected')
-    $($menuDropdownMobile[i]).find('input').attr('id', `internal-tools-toggle-mobile-${i}`)
-    $($menuDropdownMobile[i]).find('label').attr('for', `internal-tools-toggle-mobile-${i}`)
-    $($selectedSubMobile).closest('.menu-dropdown-list').siblings('.js-dropdown-toggle').prop('checked', true)
+  for (var i = 0; i < $menuDropdownMobile.length; i++) {
+    $($selectedSubMobile).parents('.menu-dropdown').addClass('selected');
+    $($menuDropdownMobile[i]).find('input').attr('id', "internal-tools-toggle-mobile-".concat(i));
+    $($menuDropdownMobile[i]).find('label').attr('for', "internal-tools-toggle-mobile-".concat(i));
+    $($selectedSubMobile).closest('.menu-dropdown-list').siblings('.js-dropdown-toggle').prop('checked', true);
   }
-}
-
+};
 /* Tooltip initializer for .js-tooltip
    ========================================================================== */
+
+
 $(function () {
   $('.js-tooltip').mouseover(function () {
-    $(this).tooltip('show')
+    $(this).tooltip('show');
     $(this).mouseout(function () {
-      $(this).tooltip('hide')
-    })
-  })
-})
-
+      $(this).tooltip('hide');
+    });
+  });
+});
 /**
  * Truncates text bases on given length.
  */
+
 $(function () {
   // How to use it: if you have an element with some text and you want to truncate it, add (data-truncate-characters=NUMBER).
-  textTruncate()
-})
+  textTruncate();
+});
 
-const textTruncate = () => {
+var textTruncate = function textTruncate() {
   // Checks the page for content to truncate
-  const charactersSelector = $('[data-truncate-characters]')
-  const pixelsSelector = $('[data-truncate-px]')
+  var charactersSelector = $('[data-truncate-characters]');
+  var pixelsSelector = $('[data-truncate-px]'); // For each founded element, call the truncate function
 
-  // For each founded element, call the truncate function
-  for (let i = 0; i < charactersSelector.length; i++) {
-    truncateAtCharacter({ selector: $('[data-truncate-characters]')[i] })
+  for (var i = 0; i < charactersSelector.length; i++) {
+    truncateAtCharacter({
+      selector: $('[data-truncate-characters]')[i]
+    });
   }
 
-  for (let i = 0; i < pixelsSelector.length; i++) {
-    truncateAtPixels({ selector: $('[data-truncate-px]')[i] })
+  for (var _i = 0; _i < pixelsSelector.length; _i++) {
+    truncateAtPixels({
+      selector: $('[data-truncate-px]')[_i]
+    });
   }
-}
+};
 
-const truncateAtCharacter = params => {
-  const { selector } = params
-
-  const truncateLength = selector.getAttribute('data-truncate-characters')
-  const initText = selector.textContent.trim()
-
+var truncateAtCharacter = function truncateAtCharacter(params) {
+  var selector = params.selector;
+  var truncateLength = selector.getAttribute('data-truncate-characters');
+  var initText = selector.textContent.trim();
   /* Add the tooltip content */
-  addTooltipBeforeTruncate({ selector })
 
-  const truncateText = selector.textContent = initText.trunc(truncateLength)
-  return truncateText
-}
+  addTooltipBeforeTruncate({
+    selector: selector
+  });
+  var truncateText = selector.textContent = initText.trunc(truncateLength);
+  return truncateText;
+};
 
-const truncateAtPixels = params => {
-  const { selector } = params
-
-  if (selector.innerText.length <= 0) return
-
-  const limitWidth = selector.getAttribute('data-truncate-px')
-  addTooltipBeforeTruncate({ selector })
-
-  return selector.setAttribute('style', `
-    max-width: ${limitWidth}px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: inline-block;
- `)
-}
-
+var truncateAtPixels = function truncateAtPixels(params) {
+  var selector = params.selector;
+  if (selector.innerText.length <= 0) return;
+  var limitWidth = selector.getAttribute('data-truncate-px');
+  addTooltipBeforeTruncate({
+    selector: selector
+  });
+  return selector.setAttribute('style', "\n    max-width: ".concat(limitWidth, "px;\n    overflow: hidden;\n    text-overflow: ellipsis;\n    white-space: nowrap;\n    display: inline-block;\n "));
+};
 /* Adds the tooltip to title before truncating the text content */
-const addTooltipBeforeTruncate = params => {
-  const { selector } = params
 
-  if (selector.innerText.length <= 0) return
 
-  selector.setAttribute('title', selector.textContent.trim()
-  )
-  selector.setAttribute('data-toggle', 'tooltip')
-}
-
+var addTooltipBeforeTruncate = function addTooltipBeforeTruncate(params) {
+  var selector = params.selector;
+  if (selector.innerText.length <= 0) return;
+  selector.setAttribute('title', selector.textContent.trim());
+  selector.setAttribute('data-toggle', 'tooltip');
+};
 /* String method to truncate a string at given value (n) */
 // eslint-disable-next-line
-String.prototype.trunc = String.prototype.trunc ||
-  function (n) { // eslint-disable-next-line
-    return (this.length > n) ? this.substring(0, n - 3) + '...' : this
-  }
+
+
+String.prototype.trunc = String.prototype.trunc || function (n) {
+  // eslint-disable-next-line
+  return this.length > n ? this.substring(0, n - 3) + '...' : this;
+};

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,8 +26,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
-  config.assets.css_compressor = :sass
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
Some of our JS was written in ES6, which required explicitly activating `Uglifier` in the production environment, in order to compress assets. Uglifier requires node.js, so this forced node to be a dependency in production.

In reality,all the assets are precompiled, so we shouldn't need any asset pipeline components in production.

In order to get back to this state, ES6 code was machine translated, via Babel, to ES5, then the original compressor command restored.