### PR TITLE
Fix the redirected view on an error during the tf plan

### DIFF
--- a/app/views/plans/_error.haml
+++ b/app/views/plans/_error.haml
@@ -1,0 +1,1 @@
+%p= @error[:output]

--- a/app/views/plans/show.html.haml
+++ b/app/views/plans/show.html.haml
@@ -3,14 +3,17 @@
   %div.card-body
     %p= markdown(t('page_subtitle.plan_info'))
     %hr
-    = loading_icon(hide: @plan.present?)
-    %div#plan
-      = render('plans/plan', plan: @plan) if @plan.present?
-  - if @plan.present?
-    %div.card-footer
-      = link_to plan_path(format: :json), class: "btn btn-outline-primary #{'disabled' unless can(deploy_path)}", title: t('tooltips.download_plan'), data: { toggle: 'tooltip' }  do
-        %i.eos-icons get_app
-        = t('sidebar.download_plan')
+    - if @error.present?
+      = render('plans/error')
+    - else
+      = loading_icon(hide: @plan.present?)
+      %div#plan
+        = render('plans/plan', plan: @plan) if @plan.present?
+    - if @plan.present?
+      %div.card-footer
+        = link_to plan_path(format: :json), class: "btn btn-outline-primary #{'disabled' unless can(deploy_path)}", title: t('tooltips.download_plan'), data: { toggle: 'tooltip' }  do
+          %i.eos-icons get_app
+          = t('sidebar.download_plan')
 %p.clearfix
   %div.float-right.btn-group.steps-container
     = link_to variables_path, class: "btn btn-secondary", title: t('tooltips.prior_step'), data: { toggle: 'tooltip' } do

--- a/spec/controllers/plans_controller_spec.rb
+++ b/spec/controllers/plans_controller_spec.rb
@@ -117,14 +117,13 @@ RSpec.describe PlansController, type: :controller do
           )
       )
 
-      put :update, format: :js
+      put :update, format: :html
 
       expect(flash[:error]).to(
-        match(
-          message: /Failed while running 'plan'./,
-          output:  'foo'
-        )
+        match('Failed while running \'plan\'')
       )
+
+      expect(response.body).to have_content('foo')
     end
   end
 end


### PR DESCRIPTION
Fix the error caused during the terraform plan if the authentication (or any terraform plan execution) fails.
https://github.com/SUSE-Enceladus/blue-horizon/issues/195

It sends the error message to the flash and the output to the body.

I have created an additional `_error` view as it is simpler to overwrite if needed (that most probably will happen).

This is the result:
![image](https://user-images.githubusercontent.com/36370954/105060377-9b1ee280-5a78-11eb-8378-9eb4a7c9f3b2.png)

This PR superseds: https://github.com/SUSE-Enceladus/blue-horizon/pull/141