### PR TITLE
Remove delete operation in plan as it is not executed

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -51,7 +51,6 @@ class PlansController < ApplicationController
     if result.is_a?(Hash)
       @trigger_update = false
       @error = result[:error]
-      File.delete(path_to_file) if File.exist?(terra.saved_plan_path)
       respond_to do |format|
         format.html do
           flash[:error] = result[:error][:message]


### PR DESCRIPTION
Just removing one line of code that I added by mistake.
The truth is that it doesn't impact the app, as the line cannot be executed (the file is always deleted in the `cleanup` method that is executed always before this).

PD:
And the test coverage was not even affected as even the code in the `if` side is not executed, checking the conditions makes the coverage catch this line...